### PR TITLE
Updates from Sean

### DIFF
--- a/payloads.js
+++ b/payloads.js
@@ -115,9 +115,23 @@ var phd_elb_api_issue = {
     "UnsubscribeURL": "https://sns.us-west-2.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:us-west-2:785665517223:guard-duty:929fb486-5851-4cdc-8b25-8cc026afea70"
 };
 
-var phd_ec2_store_drive = {
+var phd_ec2_store_drive_west2 = {
   "Type" : "Notification",
-  "Message" : "{\n    \"version\": \"0\",\n    \"id\": \"7bf73129-1428-4cd3-a780-95db273d1602\",\n    \"detail-type\": \"AWS Health Event\",\n    \"source\": \"aws.health\",\n    \"account\": \"123456789012\",\n    \"time\": \"2016-06-05T06:27:57Z\",\n    \"region\": \"us-west-2\",\n    \"resources\": [\n        \"i-abcd1111\"\n    ],\n    \"detail\": {\n        \"eventArn\": \"arn:aws:health:us-west-2::event/AWS_EC2_INSTANCE_STORE_DRIVE_PERFORMANCE_DEGRADED_90353408594353980\",\n        \"service\": \"EC2\",\n        \"eventTypeCode\": \"AWS_EC2_INSTANCE_STORE_DRIVE_PERFORMANCE_DEGRADED\",\n        \"eventTypeCategory\": \"issue\",\n        \"startTime\": \"Sat, 05 Jun 2016 15:10:09 GMT\",\n        \"eventDescription\": [\n            {\n                \"language\": \"en_US\",\n                \"latestDescription\": \"A description of the event will be provided here\"\n            }\n        ],\n        \"affectedEntities\": [\n            {\n                \"entityValue\": \"i-abcd1111\"\n            }\n        ]\n    }\n}",
+  "Message" : "{\"version\": \"0\",\"id\": \"7bf73129-1428-4cd3-a780-95db273d1602\",\"detail-type\": \"AWS Health Event\",\"source\": \"aws.health\",\"account\": \"123456789012\",\"time\": \"2016-06-05T06:27:57Z\",\"region\": \"us-west-2\",\"resources\": [\"i-abcd1111\"],\"detail\": {    \"eventArn\": \"arn:aws:health:us-west-2::event/AWS_EC2_INSTANCE_STORE_DRIVE_PERFORMANCE_DEGRADED_90353408594353980\",\"service\": \"EC2\",\"eventTypeCode\": \"AWS_EC2_INSTANCE_STORE_DRIVE_PERFORMANCE_DEGRADED\",\"eventTypeCategory\": \"issue\",\"startTime\": \"Sat, 05 Jun 2016 15:10:09 GMT\",\"eventDescription\": [{\"language\": \"en_US\",\"latestDescription\": \"A description of the event will be provided here\"}],\"affectedEntities\": [{\"entityValue\": \"i-abcd1111\"}]}\n}",
+  "SigningCertURL" : "https://sns.us-west-2.amazonaws.com/SimpleNotificationService-ac565b8b1a6c5d002d285f9598aa1d9b.pem",
+  "UnsubscribeURL" : "https://sns.us-west-2.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:us-west-2:957132980467:PHD-test:7bdb10b4-7115-4b27-9057-d423ce900543"
+};
+
+var phd_ec2_store_drive_asia2 = {
+  "Type" : "Notification",
+  "Message" : "{\"version\": \"0\",\"id\": \"7bf73129-1428-4cd3-a780-95db273d1602\",\"detail-type\": \"AWS Health Event\",\"source\": \"aws.health\",\"account\": \"123456789012\",\"time\": \"2016-06-05T06:27:57Z\",\"region\": \"ap-southeast-2\",\"resources\": [\"i-abcd1111\"],\"detail\": {    \"eventArn\": \"arn:aws:health:ap-southeast-2::event/AWS_EC2_INSTANCE_STORE_DRIVE_PERFORMANCE_DEGRADED_90353408594353980\",\"service\": \"EC2\",\"eventTypeCode\": \"AWS_EC2_INSTANCE_STORE_DRIVE_PERFORMANCE_DEGRADED\",\"eventTypeCategory\": \"issue\",\"startTime\": \"Sat, 05 Jun 2016 15:10:09 GMT\",\"eventDescription\": [{\"language\": \"en_US\",\"latestDescription\": \"A description of the event will be provided here\"}],\"affectedEntities\": [{\"entityValue\": \"i-abcd1111\"}]}\n}",
+  "SigningCertURL" : "https://sns.us-west-2.amazonaws.com/SimpleNotificationService-ac565b8b1a6c5d002d285f9598aa1d9b.pem",
+  "UnsubscribeURL" : "https://sns.us-west-2.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:us-west-2:957132980467:PHD-test:7bdb10b4-7115-4b27-9057-d423ce900543"
+};
+
+var phd_ec2_store_drive_west1 = {
+  "Type" : "Notification",
+  "Message" : "{\"version\": \"0\",\"id\": \"7bf73129-1428-4cd3-a780-95db273d1602\",\"detail-type\": \"AWS Health Event\",\"source\": \"aws.health\",\"account\": \"123456789012\",\"time\": \"2016-06-05T06:27:57Z\",\"region\": \"us-west-1\",\"resources\": [\"i-abcd1111\"],\"detail\": {    \"eventArn\": \"arn:aws:health:us-west-1::event/AWS_EC2_INSTANCE_STORE_DRIVE_PERFORMANCE_DEGRADED_90353408594353980\",\"service\": \"EC2\",\"eventTypeCode\": \"AWS_EC2_INSTANCE_STORE_DRIVE_PERFORMANCE_DEGRADED\",\"eventTypeCategory\": \"issue\",\"startTime\": \"Sat, 05 Jun 2016 15:10:09 GMT\",\"eventDescription\": [{\"language\": \"en_US\",\"latestDescription\": \"A description of the event will be provided here\"}],\"affectedEntities\": [{\"entityValue\": \"i-abcd1111\"}]}\n}",
   "SigningCertURL" : "https://sns.us-west-2.amazonaws.com/SimpleNotificationService-ac565b8b1a6c5d002d285f9598aa1d9b.pem",
   "UnsubscribeURL" : "https://sns.us-west-2.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:us-west-2:957132980467:PHD-test:7bdb10b4-7115-4b27-9057-d423ce900543"
 };
@@ -135,5 +149,11 @@ var payloads = {
     "GuardDuty: SSH Brute Force Attack": ssh_brute_force,
     "GuardDuty: DNS Data Exfiltration": dns_data_exfiltration,
     "GuardDuty: GuardDuty Changes": guard_duty_changes,
-    "GuardDuty: API's invoked": apis_invoked
+    "GuardDuty: API's invoked": apis_invoked,
+    "PHD: Elastic Load Balancer API Issue": phd_elb_api_issue,
+    "PHD: EC2 Store Drive Issue (US West 1)": phd_ec2_store_drive_west1,
+    "PHD: EC2 Store Drive Issue (US West 2)": phd_ec2_store_drive_west2,
+    "PHD: EC2 Store Drive Issue (AP SouthEast 2)": phd_ec2_store_drive_asia2,
+    "PHD: EBS Volume Lost (US East 1)": phd_ebs_volume_lost
+    
 };

--- a/payloads.js
+++ b/payloads.js
@@ -117,21 +117,21 @@ var phd_elb_api_issue = {
 
 var phd_ec2_store_drive_west2 = {
   "Type" : "Notification",
-  "Message" : "{\"version\": \"0\",\"id\": \"7bf73129-1428-4cd3-a780-95db273d1602\",\"detail-type\": \"AWS Health Event\",\"source\": \"aws.health\",\"account\": \"123456789012\",\"time\": \"2016-06-05T06:27:57Z\",\"region\": \"us-west-2\",\"resources\": [\"i-abcd1111\"],\"detail\": {    \"eventArn\": \"arn:aws:health:us-west-2::event/AWS_EC2_INSTANCE_STORE_DRIVE_PERFORMANCE_DEGRADED_90353408594353980\",\"service\": \"EC2\",\"eventTypeCode\": \"AWS_EC2_INSTANCE_STORE_DRIVE_PERFORMANCE_DEGRADED\",\"eventTypeCategory\": \"issue\",\"startTime\": \"Sat, 05 Jun 2016 15:10:09 GMT\",\"eventDescription\": [{\"language\": \"en_US\",\"latestDescription\": \"A description of the event will be provided here\"}],\"affectedEntities\": [{\"entityValue\": \"i-abcd1111\"}]}\n}",
+  "Message" : "{\"version\": \"0\",\"id\": \"7bf73129-1428-4cd3-a780-95db273d1602\",\"detail-type\": \"AWS Health Event\",\"source\": \"aws.health\",\"account\": \"123456789012\",\"time\": \"2016-06-05T06:27:57Z\",\"region\": \"us-west-2\",\"resources\": [\"i-abcd1111\"],\"detail\": {    \"eventArn\": \"arn:aws:health:us-west-2::event/AWS_EC2_INSTANCE_STORE_DRIVE_PERFORMANCE_DEGRADED_90353408594353980\",\"service\": \"EC2\",\"eventTypeCode\": \"AWS_EC2_INSTANCE_STORE_DRIVE_PERFORMANCE_DEGRADED\",\"eventTypeCategory\": \"issue\",\"startTime\": \"Sat, 05 Jun 2016 15:10:09 GMT\",\"eventDescription\": [{\"language\": \"en_US\",\"latestDescription\": \"AWS has detected a performance degradation of one or more physical storage drives that backs the instance store volumes.\"}],\"affectedEntities\": [{\"entityValue\": \"i-abcd1111\"}]}\n}",
   "SigningCertURL" : "https://sns.us-west-2.amazonaws.com/SimpleNotificationService-ac565b8b1a6c5d002d285f9598aa1d9b.pem",
   "UnsubscribeURL" : "https://sns.us-west-2.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:us-west-2:957132980467:PHD-test:7bdb10b4-7115-4b27-9057-d423ce900543"
 };
 
 var phd_ec2_store_drive_asia2 = {
   "Type" : "Notification",
-  "Message" : "{\"version\": \"0\",\"id\": \"7bf73129-1428-4cd3-a780-95db273d1602\",\"detail-type\": \"AWS Health Event\",\"source\": \"aws.health\",\"account\": \"123456789012\",\"time\": \"2016-06-05T06:27:57Z\",\"region\": \"ap-southeast-2\",\"resources\": [\"i-abcd1111\"],\"detail\": {    \"eventArn\": \"arn:aws:health:ap-southeast-2::event/AWS_EC2_INSTANCE_STORE_DRIVE_PERFORMANCE_DEGRADED_90353408594353980\",\"service\": \"EC2\",\"eventTypeCode\": \"AWS_EC2_INSTANCE_STORE_DRIVE_PERFORMANCE_DEGRADED\",\"eventTypeCategory\": \"issue\",\"startTime\": \"Sat, 05 Jun 2016 15:10:09 GMT\",\"eventDescription\": [{\"language\": \"en_US\",\"latestDescription\": \"A description of the event will be provided here\"}],\"affectedEntities\": [{\"entityValue\": \"i-abcd1111\"}]}\n}",
+  "Message" : "{\"version\": \"0\",\"id\": \"7bf73129-1428-4cd3-a780-95db273d1602\",\"detail-type\": \"AWS Health Event\",\"source\": \"aws.health\",\"account\": \"123456789012\",\"time\": \"2016-06-05T06:27:57Z\",\"region\": \"ap-southeast-2\",\"resources\": [\"i-abcd1111\"],\"detail\": {    \"eventArn\": \"arn:aws:health:ap-southeast-2::event/AWS_EC2_INSTANCE_STORE_DRIVE_PERFORMANCE_DEGRADED_90353408594353980\",\"service\": \"EC2\",\"eventTypeCode\": \"AWS_EC2_INSTANCE_STORE_DRIVE_PERFORMANCE_DEGRADED\",\"eventTypeCategory\": \"issue\",\"startTime\": \"Sat, 05 Jun 2016 15:10:09 GMT\",\"eventDescription\": [{\"language\": \"en_US\",\"latestDescription\": \"AWS has detected a performance degradation of one or more physical storage drives that backs the instance store volumes.\"}],\"affectedEntities\": [{\"entityValue\": \"i-abcd1111\"}]}\n}",
   "SigningCertURL" : "https://sns.us-west-2.amazonaws.com/SimpleNotificationService-ac565b8b1a6c5d002d285f9598aa1d9b.pem",
   "UnsubscribeURL" : "https://sns.us-west-2.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:us-west-2:957132980467:PHD-test:7bdb10b4-7115-4b27-9057-d423ce900543"
 };
 
 var phd_ec2_store_drive_west1 = {
   "Type" : "Notification",
-  "Message" : "{\"version\": \"0\",\"id\": \"7bf73129-1428-4cd3-a780-95db273d1602\",\"detail-type\": \"AWS Health Event\",\"source\": \"aws.health\",\"account\": \"123456789012\",\"time\": \"2016-06-05T06:27:57Z\",\"region\": \"us-west-1\",\"resources\": [\"i-abcd1111\"],\"detail\": {    \"eventArn\": \"arn:aws:health:us-west-1::event/AWS_EC2_INSTANCE_STORE_DRIVE_PERFORMANCE_DEGRADED_90353408594353980\",\"service\": \"EC2\",\"eventTypeCode\": \"AWS_EC2_INSTANCE_STORE_DRIVE_PERFORMANCE_DEGRADED\",\"eventTypeCategory\": \"issue\",\"startTime\": \"Sat, 05 Jun 2016 15:10:09 GMT\",\"eventDescription\": [{\"language\": \"en_US\",\"latestDescription\": \"A description of the event will be provided here\"}],\"affectedEntities\": [{\"entityValue\": \"i-abcd1111\"}]}\n}",
+  "Message" : "{\"version\": \"0\",\"id\": \"7bf73129-1428-4cd3-a780-95db273d1602\",\"detail-type\": \"AWS Health Event\",\"source\": \"aws.health\",\"account\": \"123456789012\",\"time\": \"2016-06-05T06:27:57Z\",\"region\": \"us-west-1\",\"resources\": [\"i-abcd1111\"],\"detail\": {    \"eventArn\": \"arn:aws:health:us-west-1::event/AWS_EC2_INSTANCE_STORE_DRIVE_PERFORMANCE_DEGRADED_90353408594353980\",\"service\": \"EC2\",\"eventTypeCode\": \"AWS_EC2_INSTANCE_STORE_DRIVE_PERFORMANCE_DEGRADED\",\"eventTypeCategory\": \"issue\",\"startTime\": \"Sat, 05 Jun 2016 15:10:09 GMT\",\"eventDescription\": [{\"language\": \"en_US\",\"latestDescription\": \"AWS has detected a performance degradation of one or more physical storage drives that backs the instance store volumes.\"}],\"affectedEntities\": [{\"entityValue\": \"i-abcd1111\"}]}\n}",
   "SigningCertURL" : "https://sns.us-west-2.amazonaws.com/SimpleNotificationService-ac565b8b1a6c5d002d285f9598aa1d9b.pem",
   "UnsubscribeURL" : "https://sns.us-west-2.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:us-west-2:957132980467:PHD-test:7bdb10b4-7115-4b27-9057-d423ce900543"
 };
@@ -142,6 +142,20 @@ var phd_ebs_volume_lost = {
   "SigningCertURL" : "https://sns.us-west-2.amazonaws.com/SimpleNotificationService-ac565b8b1a6c5d002d285f9598aa1d9b.pem",
   "UnsubscribeURL" : "https://sns.us-west-2.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:us-west-2:957132980467:PHD-test:7bdb10b4-7115-4b27-9057-d423ce900543"
 };
+
+var new_relic_response_time_increase = {
+  "client": "New Relic",
+  "client_url": "https://rpm.newrelic.com/accounts/1218847/incidents/17615637",
+  "description": "Alert open: Response Time > 3000ms - Server: ip-172-30-0-227",
+  "event_type": "trigger",
+  "incident_key": "/Alert/1218847/17615637/13317445",
+  "details": {
+    "ConfigurationItem": "ACME ENET",
+    "AlertMessage": "Email dispatch delay from AM-FLOR-APVM012 server. Delay: 870 secs",
+    "CI": "ACME ENET",
+    "Priority": "2 - High"
+  }
+}
 
 var payloads = {
     "CloudTrail: Add User To Group": ct_add_user_to_group,
@@ -154,6 +168,7 @@ var payloads = {
     "PHD: EC2 Store Drive Issue (US West 1)": phd_ec2_store_drive_west1,
     "PHD: EC2 Store Drive Issue (US West 2)": phd_ec2_store_drive_west2,
     "PHD: EC2 Store Drive Issue (AP SouthEast 2)": phd_ec2_store_drive_asia2,
-    "PHD: EBS Volume Lost (US East 1)": phd_ebs_volume_lost
+    "PHD: EBS Volume Lost (US East 1)": phd_ebs_volume_lost,
+    "New Relic: Response Time Increase": new_relic_response_time_increase
     
 };

--- a/sequences.js
+++ b/sequences.js
@@ -1,35 +1,58 @@
 var sequences = {
-	"Ken Sequence 1": [
+	"Demo Station 1: GuardDuty": [
 		{
-			"routing_key": services["01 Ken CloudWatch"],
+			"routing_key": services["01 Ken GuardDuty"],
 			"payload": payloads["GuardDuty: RDP Brute Force Attack"],
 			"delay": 0
 		},
 		{
-			"routing_key": services["01 Ken CloudWatch"],
+			"routing_key": services["01 Ken GuardDuty"],
 			"payload": payloads["GuardDuty: SSH Brute Force Attack"],
 			"delay": 1
 		},
 		{
-			"routing_key": services["01 Ken CloudWatch"],
+			"routing_key": services["01 Ken GuardDuty"],
 			"payload": payloads["GuardDuty: DNS Data Exfiltration"],
 			"delay": 10
 		}
 
 	],
+	"Demo Station 1: Personal Health Dashboard": [
+		{
+			"routing_key": services["01 Ken PHD"],
+			"payload": payloads["PHD: EC2 Store Drive Issue (US West 1)"],
+			"delay": 0
+		},
+		{
+			"routing_key": services["01 Ken New Relic"],
+			"payload": payloads["New Relic: Response Time Increase"],
+			"delay": 1
+		},
+		{
+			"routing_key": services["01 Ken PHD"],
+			"payload": payloads["PHD: EC2 Store Drive Issue (US West 2)"],
+			"delay": 2
+		},
+		{
+			"routing_key": services["01 Ken PHD"],
+			"payload": payloads["PHD: EC2 Store Drive Issue (AP SouthEast 2)"],
+			"delay": 3
+		}
+
+	],
 	"Eric Sequence 1": [
 		{
-			"routing_key": services["02 Eric CloudWatch"],
+			"routing_key": services["02 Eric GuardDuty"],
 			"payload": payloads["GuardDuty: RDP Brute Force Attack"],
 			"delay": 0
 		},
 		{
-			"routing_key": services["02 Eric CloudWatch"],
+			"routing_key": services["02 Eric GuardDuty"],
 			"payload": payloads["GuardDuty: SSH Brute Force Attack"],
 			"delay": 1
 		},
 		{
-			"routing_key": services["02 Eric CloudWatch"],
+			"routing_key": services["02 Eric GuardDuty"],
 			"payload": payloads["GuardDuty: DNS Data Exfiltration"],
 			"delay": 10
 		}

--- a/services.js
+++ b/services.js
@@ -1,10 +1,18 @@
 var services = {
 	"01 Ken CloudWatch": "704feb51158e47359ebf872a3ad43aee",
+	"01 Ken PHD": "f377979711fa41b593f57284fb6ebce4",
+	"01 Ken GuardDuty": "7d481e115c294f9cbf77c2796137607d",
+	"01 Ken New Relic": "f56a6e39342c42f4bf3dc05015f3123a",
 	"02 Eric CloudWatch": "61b6d2a5944b453292291dcc34d180e1",
+	"02 Eric GuardDuty": "f4c066879faf42e5aba43de9ee9d97ae",
 	"03 Masado CloudWatch": "b2e5f82381b94abd8cc15bdc7519be54",
+	"03 Masado GuardDuty": "e300f6f3f3064464810362446b0d6414",
 	"04 Edward CloudWatch": "67066c29b9234a77aa08ae4ad2402c3c",
+	"04 Edward GuardDuty": "104c29322da74b2d86af634f9294428b",
 	"05 John CloudWatch": "2a63716a97024493b592952753b60773",
+	"05 John GuardDuty": "55f233731f424cb1bb7292578f854092",
 	"06 Cheryl CloudWatch": "71e65a93e1d74f61b9de5f74c29b1a59",
+	"06 Cheryl GuardDuty": "ea0c802e91b24d15b460771bdf210f79",
 	"Martin Test Service AWS CloudWatch": "3db5a969d09647e59c118201730c7935",
 	"Martin Test Service Custom Event Transformer": "f80e23b9e8e546b8ae82dc8a908d6b3a"
 };


### PR DESCRIPTION
- Fix up PHD payloads
- Add more PHD examples, specifically EC2 related issues in multiple regions
- Added a new relic payload for response time increase
- Added GuardDuty integration keys
- Added New Relic integration keys
- Setup a sequence for PHD: it sends a bunch of notifications about EC2 storage having issues, then also fires in a new relic event (EC2 is in degraded performance == new relic picks up an increase in response time)